### PR TITLE
Change commonjs suffix to cjs

### DIFF
--- a/packages/glsl-bundler/package.json
+++ b/packages/glsl-bundler/package.json
@@ -8,16 +8,16 @@
   "repository": "plutotcool/glsl-bundler",
   "homepage": "https://github.com/plutotcool/glsl-bundler/tree/main/packages/glsl-bundler#readme",
   "bugs": "https://github.com/plutotcool/glsl-bundler/issues",
-  "main": "dist/index.js",
+  "main": "dist/index.cjs",
   "module": "dist/index.mjs",
-  "browser": "dist/index.umd.js",
+  "browser": "dist/index.umd.cjs",
   "types": "dist/index.d.ts",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs",
-      "require": "./dist/index.js",
-      "browser": "./dist/index.umd.js"
+      "require": "./dist/index.cjs",
+      "browser": "./dist/index.umd.cjs"
     }
   },
   "files": [

--- a/packages/glsl-bundler/rollup.config.js
+++ b/packages/glsl-bundler/rollup.config.js
@@ -9,24 +9,24 @@ import pkg from './package.json'
 const dir = path.dirname(pkg.main)
 
 export default {
-  input: "src/index.ts",
+  input: 'src/index.ts',
   output: [
     {
-      format: "cjs",
-      entryFileNames: "[name].cjs",
+      format: 'cjs',
+      entryFileNames: '[name].cjs',
       dir,
       preserveModules: true,
     },
     {
-      format: "es",
-      entryFileNames: "[name].mjs",
+      format: 'es',
+      entryFileNames: '[name].mjs',
       dir,
       preserveModules: true,
     },
     {
-      format: "umd",
+      format: 'umd',
       file: `${dir}/index.umd.cjs`,
-      name: "GLSLBundler",
+      name: 'GLSLBundler',
     },
   ],
   plugins: [cleaner({ targets: [dir] }), autoExternal(), eslint(), ts()],

--- a/packages/glsl-bundler/rollup.config.js
+++ b/packages/glsl-bundler/rollup.config.js
@@ -9,30 +9,25 @@ import pkg from './package.json'
 const dir = path.dirname(pkg.main)
 
 export default {
-  input: 'src/index.ts',
+  input: "src/index.ts",
   output: [
     {
-      format: 'cjs',
-      entryFileNames: '[name].js',
+      format: "cjs",
+      entryFileNames: "[name].cjs",
       dir,
-      preserveModules: true
+      preserveModules: true,
     },
     {
-      format: 'es',
-      entryFileNames: '[name].mjs',
+      format: "es",
+      entryFileNames: "[name].mjs",
       dir,
-      preserveModules: true
+      preserveModules: true,
     },
     {
-      format: 'umd',
-      file: `${dir}/index.umd.js`,
-      name: 'GLSLBundler'
-    }
+      format: "umd",
+      file: `${dir}/index.umd.cjs`,
+      name: "GLSLBundler",
+    },
   ],
-  plugins: [
-    cleaner({ targets: [dir] }),
-    autoExternal(),
-    eslint(),
-    ts()
-  ]
-}
+  plugins: [cleaner({ targets: [dir] }), autoExternal(), eslint(), ts()],
+};

--- a/packages/glsl-bundler/rollup.config.js
+++ b/packages/glsl-bundler/rollup.config.js
@@ -15,19 +15,24 @@ export default {
       format: 'cjs',
       entryFileNames: '[name].cjs',
       dir,
-      preserveModules: true,
+      preserveModules: true
     },
     {
       format: 'es',
       entryFileNames: '[name].mjs',
       dir,
-      preserveModules: true,
+      preserveModules: true
     },
     {
       format: 'umd',
       file: `${dir}/index.umd.cjs`,
-      name: 'GLSLBundler',
-    },
+      name: 'GLSLBundler'
+    }
   ],
-  plugins: [cleaner({ targets: [dir] }), autoExternal(), eslint(), ts()],
-};
+  plugins: [
+    cleaner({ targets: [dir] }),
+    autoExternal(),
+    eslint(),
+    ts()
+  ]
+}

--- a/packages/rollup-plugin-glsl/package.json
+++ b/packages/rollup-plugin-glsl/package.json
@@ -8,14 +8,14 @@
   "repository": "plutotcool/glsl-bundler",
   "homepage": "https://github.com/plutotcool/glsl-bundler/tree/main/packages/rollup-plugin-glsl#readme",
   "bugs": "https://github.com/plutotcool/glsl-bundler/issues",
-  "main": "dist/index.js",
+  "main": "dist/index.cjs",
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs",
-      "require": "./dist/index.js"
+      "require": "./dist/index.cjs"
     }
   },
   "files": [

--- a/packages/rollup-plugin-glsl/rollup.config.js
+++ b/packages/rollup-plugin-glsl/rollup.config.js
@@ -7,10 +7,10 @@ import { eslint } from 'rollup-plugin-eslint'
 import pkg from './package.json'
 
 export default {
-  input: "src/index.ts",
+  input: 'src/index.ts',
   output: [
-    { file: pkg.main, format: "cjs" },
-    { file: pkg.module, format: "es" },
+    { file: pkg.main, format: 'cjs' },
+    { file: pkg.module, format: 'es' },
   ],
   plugins: [
     cleaner({ targets: [path.dirname(pkg.main)] }),

--- a/packages/rollup-plugin-glsl/rollup.config.js
+++ b/packages/rollup-plugin-glsl/rollup.config.js
@@ -10,12 +10,12 @@ export default {
   input: 'src/index.ts',
   output: [
     { file: pkg.main, format: 'cjs' },
-    { file: pkg.module, format: 'es' },
+    { file: pkg.module, format: 'es' }
   ],
   plugins: [
     cleaner({ targets: [path.dirname(pkg.main)] }),
     autoExternal(),
     eslint(),
-    ts(),
-  ],
-};
+    ts()
+  ]
+}

--- a/packages/rollup-plugin-glsl/rollup.config.js
+++ b/packages/rollup-plugin-glsl/rollup.config.js
@@ -7,15 +7,15 @@ import { eslint } from 'rollup-plugin-eslint'
 import pkg from './package.json'
 
 export default {
-  input: 'src/index.ts',
+  input: "src/index.ts",
   output: [
-    { file: pkg.main, format: 'cjs' },
-    { file: pkg.module, format: 'es' }
+    { file: pkg.main, format: "cjs" },
+    { file: pkg.module, format: "es" },
   ],
   plugins: [
     cleaner({ targets: [path.dirname(pkg.main)] }),
     autoExternal(),
     eslint(),
     ts(),
-  ]
-}
+  ],
+};


### PR DESCRIPTION
Otherwise `require` will fail to import this module:

require("@plutotcool/rollup-plugin-glsl")
Uncaught:
Error [ERR_REQUIRE_ESM]: require() of ES Module ...\node_modules\@plutotcool\rollup-plugin-glsl\dist\index.js not supported. index.js is treated as an ES module file as it is a .js file whose nearest parent package.json contains "type": "module" which declares all .js files in that package scope as ES modules. Instead rename index.js to end in .cjs, change the requiring code to use dynamic import() which is available in all CommonJS modules, or change "type": "module" to "type": "commonjs" in ...\node_modules\@plutotcool\rollup-plugin-glsl\package.json to treat all .js files as CommonJS (using .mjs for all ES modules instead).

    at __node_internal_captureLargerStackTrace (node:internal/errors:490:5)
    at new NodeError (node:internal/errors:399:5)
    at Module._extensions..js (node:internal/modules/cjs/loader:1282:19)
    at Module.load (node:internal/modules/cjs/loader:1113:32)
    at Module._load (node:internal/modules/cjs/loader:960:12)
    at Module.require (node:internal/modules/cjs/loader:1137:19)
    at require (node:internal/modules/helpers:121:18) {
  code: 'ERR_REQUIRE_ESM'